### PR TITLE
Missing .gitignore just maven target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-**/.classpath
-**/.project
-**/.settings/
-**/target/
+target/


### PR DESCRIPTION
Without this .gitignore you'll see;
```
john@:~/forks/org.apache.commons/commons-jci (master) % git status
On branch master
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	compilers/eclipse/target/
	compilers/groovy/target/
	compilers/janino/target/
	compilers/rhino/target/
	core/target/
	examples/target/
	fam/target/
	target/

nothing added to commit but untracked files present (use "git add" to track)
john@:~/forks/org.apache.commons/commons-jci (master) %
```

I have not added any user specific ignores, like IDE files as these should probably go in the users ~/.gitignore_global as they know what IDE they choose to use.

I've checked the build using `mvn clean install -DskipTests` and everything passed.